### PR TITLE
fix(deps): Override postcss to >=8.5.10 (closes CVE-2026-41305)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2531,9 +2531,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2810,7 +2810,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "engines": {
     "node": "24.x"
-  }
-,
+  },
   "overrides": {
-    "flatted": ">=3.4.2"
+    "flatted": ">=3.4.2",
+    "postcss": ">=8.5.10"
   }
 }


### PR DESCRIPTION
## Security fix

Closes Dependabot alert #51 (CVE-2026-41305, postcss XSS via unescaped `</style>` in stringify output).

### Root cause
`postcss` is a transitive dependency of `vite` (`vite@8.0.5` -> `postcss@8.5.8`), scope development. Vite pins it as `^8.5.8`, so the vulnerable 8.5.8 was being resolved.

### Fix
Added an npm `overrides` entry forcing `postcss >=8.5.10`. Since Vite's range is a caret (`^8.5.8`), the override resolves cleanly to 8.5.15 without requiring a Vite bump.

### Verification
- `npm ls postcss` resolves to 8.5.15 (no `invalid` marker)
- `npm run build` passes (Vite)
- Override sits alongside the existing `flatted` override